### PR TITLE
ジェスチャーに割り当てる表情グループをメニューから動的に変更できるよう変更

### DIFF
--- a/Editor/Constants.cs
+++ b/Editor/Constants.cs
@@ -2,8 +2,6 @@ namespace MitarashiDango.AvatarUtils
 {
     public class Constants
     {
-        public static readonly int ADDITIONAL_FACE_EMOTE_MIN_NUMBER = 15;
-
         public static readonly string ASSET_GUID_FACE_EMOTE_LOCKING_ICON = "c0b839fd3b1aa3044bb8095cbeddbae0";
     }
 }

--- a/Editor/FaceEmoteControlParameters.cs
+++ b/Editor/FaceEmoteControlParameters.cs
@@ -10,6 +10,8 @@ namespace MitarashiDango.AvatarUtils
         public static readonly string FEC_FACE_EMOTE_LOCKED = "FEC_FaceEmoteLocked";
         public static readonly string FEC_SELECTED_GESTURE_LEFT = "FEC_SelectedGestureLeft";
         public static readonly string FEC_SELECTED_GESTURE_RIGHT = "FEC_SelectedGestureRight";
+        public static readonly string FEC_SELECTED_LEFT_GESTURE_GROUP = "FEC_SelectedLeftGestureGroup";
+        public static readonly string FEC_SELECTED_RIGHT_GESTURE_GROUP = "FEC_SelectedRightGestureGroup";
         public static readonly string FEC_FIXED_FACE_EMOTE = "FEC_FixedFaceEmote";
         public static readonly string FEC_FACE_EMOTE_LOCKER_AUTO_DISABLE_ON_SIT = "FEC_FaceEmoteLockerAutoDisableOnSit";
         public static readonly string FEC_SELECTED_FACE_EMOTE = "FEC_SelectedFaceEmote";
@@ -53,6 +55,22 @@ namespace MitarashiDango.AvatarUtils
                 new ParameterConfig
                 {
                     nameOrPrefix = FEC_SELECTED_GESTURE_RIGHT,
+                    defaultValue = 0,
+                    syncType = ParameterSyncType.Int,
+                    saved = true,
+                    localOnly = true,
+                },
+                new ParameterConfig
+                {
+                    nameOrPrefix = FEC_SELECTED_LEFT_GESTURE_GROUP,
+                    defaultValue = 0,
+                    syncType = ParameterSyncType.Int,
+                    saved = true,
+                    localOnly = true,
+                },
+                new ParameterConfig
+                {
+                    nameOrPrefix = FEC_SELECTED_RIGHT_GESTURE_GROUP,
                     defaultValue = 0,
                     syncType = ParameterSyncType.Int,
                     saved = true,

--- a/Editor/Inspectors/FaceEmoteControlEditor.cs
+++ b/Editor/Inspectors/FaceEmoteControlEditor.cs
@@ -1,5 +1,4 @@
 using UnityEditor;
-using UnityEditorInternal;
 using UnityEngine;
 
 namespace MitarashiDango.AvatarUtils
@@ -9,8 +8,7 @@ namespace MitarashiDango.AvatarUtils
     {
         private SerializedProperty defaultFaceMotion;
         private SerializedProperty time;
-        private SerializedProperty leftFaceEmoteGestureGroup;
-        private SerializedProperty rightFaceEmoteGestureGroup;
+        private SerializedProperty faceEmoteGestureGroups;
         private SerializedProperty faceEmoteGroups;
 
         private void OnEnable()
@@ -19,9 +17,7 @@ namespace MitarashiDango.AvatarUtils
 
             time = serializedObject.FindProperty("time");
 
-            leftFaceEmoteGestureGroup = serializedObject.FindProperty("leftFaceEmoteGestureGroup");
-
-            rightFaceEmoteGestureGroup = serializedObject.FindProperty("rightFaceEmoteGestureGroup");
+            faceEmoteGestureGroups = serializedObject.FindProperty("faceEmoteGestureGroups");
 
             faceEmoteGroups = serializedObject.FindProperty("faceEmoteGroups");
         }
@@ -38,21 +34,7 @@ namespace MitarashiDango.AvatarUtils
 
             EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("Left hand", EditorStyles.boldLabel);
-
-            using (new EditorGUILayout.HorizontalScope())
-            {
-                EditorGUILayout.PropertyField(leftFaceEmoteGestureGroup, new GUIContent("表情ジェスチャーグループ"), false);
-            }
-
-            EditorGUILayout.Space();
-
-            EditorGUILayout.LabelField("Right hand", EditorStyles.boldLabel);
-
-            using (new EditorGUILayout.HorizontalScope())
-            {
-                EditorGUILayout.PropertyField(rightFaceEmoteGestureGroup, new GUIContent("表情ジェスチャーグループ"), false);
-            }
+            EditorGUILayout.PropertyField(faceEmoteGestureGroups, new GUIContent("表情ジェスチャーグループ"));
 
             EditorGUILayout.Space();
 

--- a/Runtime/FaceEmoteControl.cs
+++ b/Runtime/FaceEmoteControl.cs
@@ -15,40 +15,9 @@ namespace MitarashiDango.AvatarUtils
         public float time = 0.1f;
 
         [HideInInspector]
-        public FaceEmoteGestureGroup leftFaceEmoteGestureGroup;
-
-        [HideInInspector]
-        public FaceEmoteGestureGroup rightFaceEmoteGestureGroup;
+        public List<FaceEmoteGestureGroup> faceEmoteGestureGroups;
 
         [HideInInspector]
         public List<FaceEmoteGroup> faceEmoteGroups;
-
-        public bool IsLeftGestureAvailable
-        {
-            get
-            {
-                return leftFaceEmoteGestureGroup?.fist?.motion != null
-                    || leftFaceEmoteGestureGroup?.handOpen?.motion != null
-                    || leftFaceEmoteGestureGroup?.fingerPoint?.motion != null
-                    || leftFaceEmoteGestureGroup?.victory?.motion != null
-                    || leftFaceEmoteGestureGroup?.rockNRoll?.motion != null
-                    || leftFaceEmoteGestureGroup?.handGun?.motion != null
-                    || leftFaceEmoteGestureGroup?.thumbsUp?.motion != null;
-            }
-        }
-
-        public bool IsRightGestureAvailable
-        {
-            get
-            {
-                return rightFaceEmoteGestureGroup?.fist?.motion != null
-                    || rightFaceEmoteGestureGroup?.handOpen?.motion != null
-                    || rightFaceEmoteGestureGroup?.fingerPoint?.motion != null
-                    || rightFaceEmoteGestureGroup?.victory?.motion != null
-                    || rightFaceEmoteGestureGroup?.rockNRoll?.motion != null
-                    || rightFaceEmoteGestureGroup?.handGun?.motion != null
-                    || rightFaceEmoteGestureGroup?.thumbsUp?.motion != null;
-            }
-        }
     }
 }


### PR DESCRIPTION
- ジェスチャー割当用表情グループを複数設定できるようデータ構造を変更
  - 従来の設定はクリアされるため、更新後に再割当が必要
- メニューへ表情グループを左右のジェスチャーへ割り当てる項目を追加
- ジェスチャー切り替えに対応するようAnimatorControllerの構造を変更