### PR TITLE
表情固定用メニュー項目のフォールバック時の命名条件を変更

### DIFF
--- a/Editor/FaceEmoteControlMenuGenerator.cs
+++ b/Editor/FaceEmoteControlMenuGenerator.cs
@@ -229,7 +229,7 @@ namespace MitarashiDango.AvatarUtils
 
         private GameObject GenerateFixedFaceEmoteMenuItem(FaceEmote faceEmote, string defaultName, float parameterValue)
         {
-            var name = faceEmote.name != "" ? faceEmote.name : defaultName;
+            var name = faceEmote.FaceEmoteName != "" ? faceEmote.FaceEmoteName : defaultName;
             return GenerateToggleMenuItem(name, faceEmote.icon, FaceEmoteControlParameters.FEC_FIXED_FACE_EMOTE, parameterValue);
         }
 

--- a/Runtime/FaceEmote.cs
+++ b/Runtime/FaceEmote.cs
@@ -21,6 +21,6 @@ namespace MitarashiDango.AvatarUtils
         [HideInInspector]
         public TrackingControlType mouthControlType;
 
-        public string FaceEmoteName => (name != "" ? name : motion?.name) ?? "";
+        public string FaceEmoteName => !string.IsNullOrEmpty(name) ? name : motion?.name ?? "";
     }
 }

--- a/Runtime/FaceEmote.cs
+++ b/Runtime/FaceEmote.cs
@@ -20,5 +20,7 @@ namespace MitarashiDango.AvatarUtils
 
         [HideInInspector]
         public TrackingControlType mouthControlType;
+
+        public string FaceEmoteName => (name != "" ? name : motion?.name) ?? "";
     }
 }


### PR DESCRIPTION
表情名が未設定の場合、アニメーション自体に名前が設定されている場合はそれを優先的に使用するようにする。
アニメーションにも名前が設定されていない場合、従来通り連番またはジェスチャー名での命名とする。