### PR TITLE
表情コントロール用コンポーネントのメニューをサブメニューとして生成するよう変更

### DIFF
--- a/Editor/FaceEmoteControlMenuGenerator.cs
+++ b/Editor/FaceEmoteControlMenuGenerator.cs
@@ -8,18 +8,17 @@ namespace MitarashiDango.AvatarUtils
 {
     public class FaceEmoteControlMenuGenerator
     {
-        public GameObject GenerateMenus(FaceEmoteControl faceEmoteControl)
+        public void GenerateMenu(FaceEmoteControl faceEmoteControl)
         {
-            var menuTree = GenerateFaceEmoteControlMenu(faceEmoteControl);
-            menuTree.AddComponent<ModularAvatarMenuInstaller>();
+            var modularAvatarMenuItem = faceEmoteControl.gameObject.AddComponent<ModularAvatarMenuItem>();
+            modularAvatarMenuItem.Control.type = VRCExpressionsMenu.Control.ControlType.SubMenu;
+            modularAvatarMenuItem.MenuSource = SubmenuSource.Children;
 
-            return menuTree;
+            GenerateFaceEmoteControlMenuItems(faceEmoteControl);
         }
 
-        private GameObject GenerateFaceEmoteControlMenu(FaceEmoteControl faceEmoteControl)
+        private void GenerateFaceEmoteControlMenuItems(FaceEmoteControl faceEmoteControl)
         {
-            var subMenu = GenerateSubMenu("表情操作", null);
-
             var subMenuItems = new List<GameObject>
             {
                 GenerateToggleMenuItem("表情コントロールON", null, FaceEmoteControlParameters.FEC_ON, 1),
@@ -31,10 +30,8 @@ namespace MitarashiDango.AvatarUtils
 
             foreach (var subMenuItem in subMenuItems)
             {
-                subMenuItem.transform.parent = subMenu.transform;
+                subMenuItem.transform.parent = faceEmoteControl.transform;
             }
-
-            return subMenu;
         }
 
         private GameObject GenerateFaceLockMenu()

--- a/Editor/FaceEmoteControlProcessor.cs
+++ b/Editor/FaceEmoteControlProcessor.cs
@@ -16,11 +16,11 @@ namespace MitarashiDango.AvatarUtils
                 return;
             }
 
-            var fecRootGameObject = GenerateHeadBoneChildObject();
-            fecRootGameObject.transform.SetParent(faceEmoteControl.gameObject.transform);
+            var headProxyGameObject = GenerateHeadBoneChildObject();
+            headProxyGameObject.transform.SetParent(ctx.AvatarRootObject.transform);
 
-            var faceEmoteLocker = GenerateFaceEmoteLocker(fecRootGameObject);
-            faceEmoteLocker.transform.SetParent(faceEmoteControl.gameObject.transform);
+            var faceEmoteLocker = GenerateFaceEmoteLocker(headProxyGameObject);
+            faceEmoteLocker.transform.SetParent(ctx.AvatarRootObject.transform);
 
             AddParameters(faceEmoteControl.gameObject, faceEmoteControl);
             AddMenuItems(faceEmoteControl.gameObject, faceEmoteControl);
@@ -53,7 +53,7 @@ namespace MitarashiDango.AvatarUtils
 
         private GameObject GenerateHeadBoneChildObject()
         {
-            var go = new GameObject("FaceEmoteControl_Root");
+            var go = new GameObject("$$FaceEmoteControl$$HeadProxy");
 
             var modularAvatarBoneProxy = go.AddComponent<ModularAvatarBoneProxy>();
             modularAvatarBoneProxy.attachmentMode = BoneProxyAttachmentMode.AsChildAtRoot;
@@ -64,7 +64,7 @@ namespace MitarashiDango.AvatarUtils
 
         private GameObject GenerateFaceEmoteLocker(GameObject rootGameObject)
         {
-            var go = new GameObject("FaceEmoteLocker");
+            var go = new GameObject("$$FaceEmoteControl$$FaceEmoteLockContactReceiver");
 
             var vrcContactReceiver = go.AddComponent<VRCContactReceiver>();
             vrcContactReceiver.rootTransform = rootGameObject.transform;

--- a/Editor/FaceEmoteControlProcessor.cs
+++ b/Editor/FaceEmoteControlProcessor.cs
@@ -23,7 +23,7 @@ namespace MitarashiDango.AvatarUtils
             faceEmoteLocker.transform.SetParent(ctx.AvatarRootObject.transform);
 
             AddParameters(faceEmoteControl.gameObject, faceEmoteControl);
-            AddMenuItems(faceEmoteControl.gameObject, faceEmoteControl);
+            GenerateMenu(faceEmoteControl);
             AddAnimatorController(faceEmoteControl);
             Object.DestroyImmediate(faceEmoteControl);
         }
@@ -35,10 +35,10 @@ namespace MitarashiDango.AvatarUtils
             modularAvatarParameters.parameters = parameters.GetParameterConfigs(faceEmoteControl);
         }
 
-        private void AddMenuItems(GameObject obj, FaceEmoteControl faceEmoteControl)
+        private void GenerateMenu(FaceEmoteControl faceEmoteControl)
         {
             var menuBuilder = new FaceEmoteControlMenuGenerator();
-            menuBuilder.GenerateMenus(faceEmoteControl).transform.parent = obj.transform;
+            menuBuilder.GenerateMenu(faceEmoteControl);
         }
 
         private void AddAnimatorController(FaceEmoteControl faceEmoteControl)


### PR DESCRIPTION
現状、アバターメニューのルートにメニュー項目を生成していたため、独自のメニュー階層の作成が不可となっていた。
本Pull-Requestでは、サブメニューとしてメニュー項目が生成されるよう変更されているため、任意のメニュー階層にコンポーネントのメニュー項目を設置することが可能となっている。

また、本変更の適用後、メニュー階層のサブメニュー項目としてコンポーネントを配置しない場合は同一オブジェクトへMA Menu Installerの追加を手動で行う必要がある。